### PR TITLE
feat: project refactor with filtering, pagination, GitHub integration, and new layout

### DIFF
--- a/app/projects/[repoName]/loading.tsx
+++ b/app/projects/[repoName]/loading.tsx
@@ -4,15 +4,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function Loading() {
   return (
     <div className="max-w-7xl mx-auto">
-      {/* Breadcrumb Skeleton */}
-      <div className="flex items-center gap-2 mb-8">
-        <Skeleton className="h-4 w-12" />
-        <span className="text-muted-foreground">/</span>
-        <Skeleton className="h-4 w-16" />
-        <span className="text-muted-foreground">/</span>
-        <Skeleton className="h-4 w-28" />
-      </div>
-
       {/* Main Grid */}
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
         {/* Left/Main Column - Readme Skeleton (3/4 width) */}

--- a/components/cards/ProjectCard.tsx
+++ b/components/cards/ProjectCard.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import Link from "next/link";
-import { ExternalLink, Github, BookOpen, Star, GitFork } from "lucide-react";
+import { ExternalLink, Github, BookOpen, Star, GitFork, GitBranch } from "lucide-react";
 import { ProjectItem } from "@/types";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -18,6 +18,7 @@ const ProjectCard = ({
   forks,
   updatedAt,
   language,
+  latestCommit,
 }: ProjectItem) => {
   return (
     <Card
@@ -50,18 +51,29 @@ const ProjectCard = ({
           {description}
         </p>
 
-        <div className="flex flex-wrap gap-1.5 mb-4">
-          {technologies.map((tech, index) => (
-            <Badge key={index} variant="secondary" className="text-[10px]">
-              {tech}
-            </Badge>
-          ))}
-        </div>
+        {technologies.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mb-4">
+            {technologies.map((tech, index) => (
+              <Badge key={index} variant="secondary" className="text-[10px]">
+                {tech}
+              </Badge>
+            ))}
+          </div>
+        )}
 
-        {/* Metadata Row: Language & Last Updated */}
+        {/* Commit metadata */}
+        {latestCommit && (
+          <div className="flex items-center gap-1 font-mono text-[11px] mb-2 truncate min-w-0" title={`${latestCommit.branch}: ${latestCommit.message}`}>
+            <GitBranch className="h-3 w-3 shrink-0 text-primary" />
+            <span className="text-primary font-semibold shrink-0">{latestCommit.branch}</span>
+            <span className="text-muted-foreground truncate">:{latestCommit.message.split('\n')[0]}</span>
+          </div>
+        )}
+
+        {/* Language & Last Updated */}
         <div className="flex items-center justify-between text-[11px] text-muted-foreground mb-4">
           {language && (
-            <span className="flex items-center gap-1.5 font-medium">
+            <span className="flex items-center gap-1 font-medium">
               <span className="h-2 w-2 rounded-full bg-primary" />
               {language}
             </span>

--- a/components/features/ProjectsFilterBar.tsx
+++ b/components/features/ProjectsFilterBar.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import React from "react";
+import { Search, ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+} from "@/components/ui/dropdown-menu";
+
+interface FilterBarProps {
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  selectedTopic: string;
+  onTopicChange: (value: string) => void;
+  selectedLanguage: string;
+  onLanguageChange: (value: string) => void;
+  sortBy: "name" | "updated";
+  sortOrder: "asc" | "desc";
+  onSortClick: (field: "name" | "updated") => void;
+  featuredOnly: boolean;
+  onFeaturedToggle: () => void;
+  allTopics: string[];
+  allLanguages: string[];
+  topicCounts: Record<string, number>;
+  languageCounts: Record<string, number>;
+  totalProjects: number;
+  resultCount: number;
+}
+
+export default function ProjectsFilterBar({
+  searchQuery,
+  onSearchChange,
+  selectedTopic,
+  onTopicChange,
+  selectedLanguage,
+  onLanguageChange,
+  sortBy,
+  sortOrder,
+  onSortClick,
+  featuredOnly,
+  onFeaturedToggle,
+  allTopics,
+  allLanguages,
+  topicCounts,
+  languageCounts,
+  totalProjects,
+  resultCount,
+}: FilterBarProps) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between border border-border/40 p-4 rounded-xl bg-card/20 backdrop-blur-md shadow-sm">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          variant={featuredOnly ? "default" : "outline"}
+          size="sm"
+          onClick={onFeaturedToggle}
+          className="h-8 text-xs rounded-lg border border-border"
+        >
+          Featured
+        </Button>
+
+        <div className="inline-flex rounded-lg border border-border p-0.5 shadow-sm">
+          <Button
+            variant={sortBy !== "name" ? "ghost" : undefined}
+            size="sm"
+            onClick={() => onSortClick("name")}
+            className="h-7 text-xs rounded-md px-3 gap-0.5"
+          >
+            Name {sortBy === "name" && (sortOrder === "asc" ? "↑" : "↓")}
+          </Button>
+          <Button
+            variant={sortBy !== "updated" ? "ghost" : undefined}
+            size="sm"
+            onClick={() => onSortClick("updated")}
+            className="h-7 text-xs rounded-md px-3 gap-0.5"
+          >
+            Updated{" "}
+            {sortBy === "updated" && (sortOrder === "asc" ? "↑" : "↓")}
+          </Button>
+        </div>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 text-xs rounded-lg gap-1 border border-border bg-card"
+            >
+              <span className="capitalize">
+                {selectedTopic === "all"
+                  ? `All Topics (${totalProjects})`
+                  : `${selectedTopic} (${topicCounts[selectedTopic] || 0})`}
+              </span>
+              <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            className="w-48 bg-card border border-border max-h-64 overflow-y-auto rounded-lg shadow-lg"
+          >
+            <DropdownMenuRadioGroup
+              value={selectedTopic}
+              onValueChange={onTopicChange}
+            >
+              <DropdownMenuRadioItem
+                value="all"
+                className="text-xs cursor-pointer focus:bg-accent rounded"
+              >
+                All Topics ({totalProjects})
+              </DropdownMenuRadioItem>
+              {allTopics.map((topic) => (
+                <DropdownMenuRadioItem
+                  key={topic}
+                  value={topic}
+                  className="text-xs uppercase cursor-pointer focus:bg-accent rounded"
+                >
+                  {topic} ({topicCounts[topic] || 0})
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 text-xs rounded-lg gap-1 border border-border bg-card"
+            >
+              <span className="capitalize">
+                {selectedLanguage === "all"
+                  ? `All Languages (${totalProjects})`
+                  : `${selectedLanguage} (${languageCounts[selectedLanguage] || 0})`}
+              </span>
+              <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            className="w-48 bg-card border border-border max-h-64 overflow-y-auto rounded-lg shadow-lg"
+          >
+            <DropdownMenuRadioGroup
+              value={selectedLanguage}
+              onValueChange={onLanguageChange}
+            >
+              <DropdownMenuRadioItem
+                value="all"
+                className="text-xs cursor-pointer focus:bg-accent rounded"
+              >
+                All Languages ({totalProjects})
+              </DropdownMenuRadioItem>
+              {allLanguages.map((lang) => (
+                <DropdownMenuRadioItem
+                  key={lang}
+                  value={lang}
+                  className="text-xs cursor-pointer focus:bg-accent rounded"
+                >
+                  {lang} ({languageCounts[lang] || 0})
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="w-full sm:w-80">
+        <label className="sr-only" htmlFor="project-search">
+          Search projects
+        </label>
+        <div className="relative flex items-center bg-card border border-border rounded-lg shadow-sm hover:border-border/80 transition-all focus-within:border-primary focus-within:ring-1 focus-within:ring-primary/20 overflow-hidden h-8">
+          <div className="pl-3 text-muted-foreground flex items-center">
+            <Search className="h-3.5 w-3.5" />
+          </div>
+          <input
+            id="project-search"
+            type="search"
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search projects"
+            className="w-full pl-2 bg-transparent text-xs outline-none text-foreground placeholder:text-muted-foreground"
+          />
+          <div className="absolute right-3 text-[10px] text-muted-foreground font-medium select-none pointer-events-none bg-muted px-1.5 py-0.5 rounded border border-border/40">
+            {resultCount} results
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/features/ProjectsList.tsx
+++ b/components/features/ProjectsList.tsx
@@ -1,39 +1,26 @@
 "use client";
 
 import React, { useState, useMemo, useEffect } from "react";
-import {
-  Search,
-  ChevronLeft,
-  ChevronRight,
-  ChevronDown,
-  Cpu,
-} from "lucide-react";
+import { Cpu } from "lucide-react";
 import { ProjectCard } from "@/components/cards";
 import { ProjectItem } from "@/types";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-} from "@/components/ui/dropdown-menu";
+import ProjectsFilterBar from "@/components/features/ProjectsFilterBar";
+import ProjectsPagination from "@/components/features/ProjectsPagination";
 
 interface ProjectsListProps {
   initialProjects: ProjectItem[];
 }
 
 export default function ProjectsList({ initialProjects }: ProjectsListProps) {
-  // Client-side states
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTopic, setSelectedTopic] = useState("all");
+  const [selectedLanguage, setSelectedLanguage] = useState("all");
   const [sortBy, setSortBy] = useState<"name" | "updated">("updated");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [featuredOnly, setFeaturedOnly] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 6;
 
-  // Extract unique topics across all repositories
   const allTopics = useMemo(() => {
     const topicsSet = new Set<string>();
     initialProjects.forEach((proj) => {
@@ -44,12 +31,42 @@ export default function ProjectsList({ initialProjects }: ProjectsListProps) {
     return Array.from(topicsSet).sort();
   }, [initialProjects]);
 
-  // Reset page to 1 when filters, sorting, or search query changes
+  const allLanguages = useMemo(() => {
+    const langSet = new Set<string>();
+    initialProjects.forEach((proj) => {
+      if (proj.language) {
+        langSet.add(proj.language.toLowerCase());
+      }
+    });
+    return Array.from(langSet).sort();
+  }, [initialProjects]);
+
+  const topicCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    initialProjects.forEach((proj) => {
+      proj.technologies?.forEach((tech) => {
+        const key = tech.toLowerCase();
+        counts[key] = (counts[key] || 0) + 1;
+      });
+    });
+    return counts;
+  }, [initialProjects]);
+
+  const languageCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    initialProjects.forEach((proj) => {
+      if (proj.language) {
+        const key = proj.language.toLowerCase();
+        counts[key] = (counts[key] || 0) + 1;
+      }
+    });
+    return counts;
+  }, [initialProjects]);
+
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchQuery, selectedTopic, sortBy, sortOrder, featuredOnly]);
+  }, [searchQuery, selectedTopic, selectedLanguage, sortBy, sortOrder, featuredOnly]);
 
-  // Handle Sort button clicks
   const handleSortClick = (field: "name" | "updated") => {
     if (sortBy === field) {
       setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
@@ -59,9 +76,7 @@ export default function ProjectsList({ initialProjects }: ProjectsListProps) {
     }
   };
 
-  // Filter and sort repositories
   const processedProjects = useMemo(() => {
-    // 1. Filter by search query
     let filtered = initialProjects.filter((proj) => {
       const nameMatch = proj.project
         .toLowerCase()
@@ -72,24 +87,26 @@ export default function ProjectsList({ initialProjects }: ProjectsListProps) {
       return nameMatch || descMatch;
     });
 
-    // 2. Filter by topic
     if (selectedTopic !== "all") {
       filtered = filtered.filter((proj) =>
         proj.technologies?.some((tech) => tech.toLowerCase() === selectedTopic),
       );
     }
 
-    // 3. Filter by featured (pinned) only
+    if (selectedLanguage !== "all") {
+      filtered = filtered.filter((proj) =>
+        proj.language?.toLowerCase() === selectedLanguage,
+      );
+    }
+
     if (featuredOnly) {
       filtered = filtered.filter((proj) => proj.highlight === "PINNED");
     }
 
-    // 4. Sort projects: Pinned items are always placed at the top first, then apply criteria
     return [...filtered].sort((a, b) => {
       const isAPinned = a.highlight === "PINNED";
       const isBPinned = b.highlight === "PINNED";
 
-      // Pin priorities go first (only if we're not already filtering solely by featured)
       if (!featuredOnly) {
         if (isAPinned && !isBPinned) return -1;
         if (!isAPinned && isBPinned) return 1;
@@ -99,10 +116,10 @@ export default function ProjectsList({ initialProjects }: ProjectsListProps) {
       if (sortBy === "updated") {
         const dateA = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
         const dateB = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
-        compare = dateB - dateA; // Default: recent first (desc)
+        compare = dateB - dateA;
         return sortOrder === "desc" ? compare : -compare;
       } else {
-        compare = a.project.localeCompare(b.project); // Default: A to Z (asc)
+        compare = a.project.localeCompare(b.project);
         return sortOrder === "asc" ? compare : -compare;
       }
     });
@@ -110,161 +127,42 @@ export default function ProjectsList({ initialProjects }: ProjectsListProps) {
     initialProjects,
     searchQuery,
     selectedTopic,
+    selectedLanguage,
     sortBy,
     sortOrder,
     featuredOnly,
   ]);
 
-  // Pagination bounds
-  const totalPages = Math.max(
-    1,
-    Math.ceil(processedProjects.length / itemsPerPage),
-  );
+  const totalPages = Math.max(1, Math.ceil(processedProjects.length / itemsPerPage));
   const paginatedProjects = useMemo(() => {
     const startIndex = (currentPage - 1) * itemsPerPage;
     return processedProjects.slice(startIndex, startIndex + itemsPerPage);
   }, [processedProjects, currentPage, itemsPerPage]);
 
-  // Generate pagination layout: [first 2] .... [last 2] with current middle page
-  const pageButtons = useMemo(() => {
-    const pages: (number | string)[] = [];
-    if (totalPages <= 4) {
-      for (let i = 1; i <= totalPages; i++) {
-        pages.push(i);
-      }
-    } else {
-      // Always push first 2 pages
-      pages.push(1, 2);
-
-      // If current page is in the middle, render it in the center slot
-      if (currentPage > 2 && currentPage < totalPages - 1) {
-        if (currentPage > 3) pages.push("....");
-        pages.push(currentPage);
-        if (currentPage < totalPages - 2) pages.push("....");
-      } else {
-        pages.push("....");
-      }
-
-      // Always push last 2 pages
-      pages.push(totalPages - 1, totalPages);
-    }
-    return pages;
-  }, [currentPage, totalPages]);
-
   return (
-    <div className="space-y-8 max-w-7xl mx-auto font-sans">
-      {/* Filters and Controls Bar */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between border border-border/40 p-4 rounded-xl bg-card/20 backdrop-blur-md shadow-sm">
-        {/* Left Action Buttons */}
-        <div className="flex flex-wrap items-center gap-2">
-          {/* Featured Toggle Button */}
-          <Button
-            variant={featuredOnly ? "default" : "outline"}
-            size="sm"
-            onClick={() => setFeaturedOnly((prev) => !prev)}
-            className="h-8 text-xs rounded-lg border border-border"
-          >
-            Featured
-          </Button>
+    <div className="space-y-4 max-w-7xl mx-auto font-sans">
+      <ProjectsFilterBar
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        selectedTopic={selectedTopic}
+        onTopicChange={setSelectedTopic}
+        selectedLanguage={selectedLanguage}
+        onLanguageChange={setSelectedLanguage}
+        sortBy={sortBy}
+        sortOrder={sortOrder}
+        onSortClick={handleSortClick}
+        featuredOnly={featuredOnly}
+        onFeaturedToggle={() => setFeaturedOnly((prev) => !prev)}
+        allTopics={allTopics}
+        allLanguages={allLanguages}
+        topicCounts={topicCounts}
+        languageCounts={languageCounts}
+        totalProjects={initialProjects.length}
+        resultCount={processedProjects.length}
+      />
 
-          {/* Sort Buttons Group */}
-          <div className="inline-flex rounded-lg border border-border p-0.5 shadow-sm">
-            <Button
-              variant={sortBy !== "name" ? "ghost" : undefined}
-              size="sm"
-              onClick={() => handleSortClick("name")}
-              className="h-7 text-xs rounded-md px-3 gap-0.5"
-            >
-              Name {sortBy === "name" && (sortOrder === "asc" ? "↑" : "↓")}
-            </Button>
-            <Button
-              variant={sortBy !== "updated" ? "ghost" : undefined}
-              size="sm"
-              onClick={() => handleSortClick("updated")}
-              className="h-7 text-xs rounded-md px-3 gap-0.5"
-            >
-              Updated{" "}
-              {sortBy === "updated" && (sortOrder === "asc" ? "↑" : "↓")}
-            </Button>
-          </div>
-
-          {/* Topics Dropdown */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-8 text-xs rounded-lg gap-1 border border-border bg-card"
-              >
-                <span className="capitalize">
-                  {selectedTopic === "all"
-                    ? `All Topics (${initialProjects.length})`
-                    : `${selectedTopic} (${initialProjects.filter((p) => p.technologies?.some((t) => t.toLowerCase() === selectedTopic)).length})`}
-                </span>
-                <ChevronDown className="h-3.5 w-3.5 opacity-60" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="start"
-              className="w-48 bg-card border border-border max-h-64 overflow-y-auto rounded-lg shadow-lg"
-            >
-              <DropdownMenuRadioGroup
-                value={selectedTopic}
-                onValueChange={setSelectedTopic}
-              >
-                <DropdownMenuRadioItem
-                  value="all"
-                  className="text-xs cursor-pointer focus:bg-accent rounded"
-                >
-                  All Topics ({initialProjects.length})
-                </DropdownMenuRadioItem>
-                {allTopics.map((topic) => {
-                  const count = initialProjects.filter((p) =>
-                    p.technologies?.some((t) => t.toLowerCase() === topic),
-                  ).length;
-
-                  return (
-                    <DropdownMenuRadioItem
-                      key={topic}
-                      value={topic}
-                      className="text-xs uppercase cursor-pointer focus:bg-accent rounded"
-                    >
-                      {topic} ({count})
-                    </DropdownMenuRadioItem>
-                  );
-                })}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-
-        {/* Right Search Input Group */}
-        <div className="w-full sm:w-80">
-          <label className="sr-only" htmlFor="project-search">
-            Search projects
-          </label>
-          <div className="relative flex items-center bg-card border border-border rounded-lg shadow-sm hover:border-border/80 transition-all focus-within:border-primary focus-within:ring-1 focus-within:ring-primary/20 overflow-hidden h-8">
-            <div className="pl-3 text-muted-foreground flex items-center">
-              <Search className="h-3.5 w-3.5" />
-            </div>
-            <input
-              id="project-search"
-              type="search"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search projects"
-              className="w-full pl-2 bg-transparent text-xs outline-none text-foreground placeholder:text-muted-foreground"
-            />
-            <div className="absolute right-3 text-[10px] text-muted-foreground font-medium select-none pointer-events-none bg-muted px-1.5 py-0.5 rounded border border-border/40">
-              {processedProjects.length} results
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Projects Grid */}
       {paginatedProjects.length > 0 ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 pt-2">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {paginatedProjects.map((project) => (
             <ProjectCard key={project.project} {...project} />
           ))}
@@ -279,78 +177,13 @@ export default function ProjectsList({ initialProjects }: ProjectsListProps) {
         </div>
       )}
 
-      {/* Pagination Controls */}
-      {totalPages > 1 && (
-        <div className="flex flex-col sm:flex-row items-center justify-between gap-4 pt-6 border-t border-border/40 font-sans">
-          {/* Status text */}
-          <span className="text-sm text-muted-foreground">
-            Showing{" "}
-            <span className="font-semibold text-foreground">
-              {(currentPage - 1) * itemsPerPage + 1}
-            </span>{" "}
-            to{" "}
-            <span className="font-semibold text-foreground">
-              {Math.min(currentPage * itemsPerPage, processedProjects.length)}
-            </span>{" "}
-            of{" "}
-            <span className="font-semibold text-foreground">
-              {processedProjects.length}
-            </span>{" "}
-            projects
-          </span>
-
-          {/* Page buttons */}
-          <div className="flex items-center gap-1.5">
-            <button
-              onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
-              disabled={currentPage === 1}
-              className="p-2 rounded-lg border border-border/80 hover:bg-muted text-muted-foreground disabled:opacity-40 disabled:hover:bg-transparent transition-all active:scale-95 h-8 w-8 flex items-center justify-center"
-              aria-label="Previous page"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </button>
-
-            {pageButtons.map((page, index) => {
-              if (page === "....") {
-                return (
-                  <span
-                    key={`ellipsis-${index}`}
-                    className="px-1.5 text-muted-foreground select-none text-xs font-semibold tracking-widest leading-8"
-                  >
-                    ....
-                  </span>
-                );
-              }
-
-              const pageNum = page as number;
-              return (
-                <button
-                  key={`page-${pageNum}`}
-                  onClick={() => setCurrentPage(pageNum)}
-                  className={`w-8 h-8 rounded-lg text-xs font-semibold border transition-all active:scale-95 ${
-                    currentPage === pageNum
-                      ? "bg-primary border-primary text-primary-foreground shadow-sm"
-                      : "bg-card border-border/80 text-muted-foreground hover:text-foreground hover:bg-muted"
-                  }`}
-                >
-                  {pageNum}
-                </button>
-              );
-            })}
-
-            <button
-              onClick={() =>
-                setCurrentPage((prev) => Math.min(totalPages, prev + 1))
-              }
-              disabled={currentPage === totalPages}
-              className="p-2 rounded-lg border border-border/80 hover:bg-muted text-muted-foreground disabled:opacity-40 disabled:hover:bg-transparent transition-all active:scale-95 h-8 w-8 flex items-center justify-center"
-              aria-label="Next page"
-            >
-              <ChevronRight className="h-4 w-4" />
-            </button>
-          </div>
-        </div>
-      )}
+      <ProjectsPagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        itemsPerPage={itemsPerPage}
+        totalItems={processedProjects.length}
+        onPageChange={setCurrentPage}
+      />
     </div>
   );
 }

--- a/components/features/ProjectsPagination.tsx
+++ b/components/features/ProjectsPagination.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React, { useMemo } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  itemsPerPage: number;
+  totalItems: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function ProjectsPagination({
+  currentPage,
+  totalPages,
+  itemsPerPage,
+  totalItems,
+  onPageChange,
+}: PaginationProps) {
+  const pageButtons = useMemo(() => {
+    const pages: (number | string)[] = [];
+    if (totalPages <= 4) {
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i);
+      }
+    } else {
+      pages.push(1, 2);
+
+      if (currentPage > 2 && currentPage < totalPages - 1) {
+        if (currentPage > 3) pages.push("....");
+        pages.push(currentPage);
+        if (currentPage < totalPages - 2) pages.push("....");
+      } else {
+        pages.push("....");
+      }
+
+      pages.push(totalPages - 1, totalPages);
+    }
+    return pages;
+  }, [currentPage, totalPages]);
+
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex flex-col sm:flex-row items-center justify-between gap-4 pt-6 border-t border-border/40 font-sans">
+      <span className="text-sm text-muted-foreground">
+        Showing{" "}
+        <span className="font-semibold text-foreground">
+          {(currentPage - 1) * itemsPerPage + 1}
+        </span>{" "}
+        to{" "}
+        <span className="font-semibold text-foreground">
+          {Math.min(currentPage * itemsPerPage, totalItems)}
+        </span>{" "}
+        of{" "}
+        <span className="font-semibold text-foreground">
+          {totalItems}
+        </span>{" "}
+        projects
+      </span>
+
+      <div className="flex items-center gap-1.5">
+        <button
+          onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+          disabled={currentPage === 1}
+          className="p-2 rounded-lg border border-border/80 hover:bg-muted text-muted-foreground disabled:opacity-40 disabled:hover:bg-transparent transition-all active:scale-95 h-8 w-8 flex items-center justify-center"
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+
+        {pageButtons.map((page, index) => {
+          if (page === "....") {
+            return (
+              <span
+                key={`ellipsis-${index}`}
+                className="px-1.5 text-muted-foreground select-none text-xs font-semibold tracking-widest leading-8"
+              >
+                ....
+              </span>
+            );
+          }
+
+          const pageNum = page as number;
+          return (
+            <button
+              key={`page-${pageNum}`}
+              onClick={() => onPageChange(pageNum)}
+              className={`w-8 h-8 rounded-lg text-xs font-semibold border transition-all active:scale-95 ${
+                currentPage === pageNum
+                  ? "bg-primary border-primary text-primary-foreground shadow-sm"
+                  : "bg-card border-border/80 text-muted-foreground hover:text-foreground hover:bg-muted"
+              }`}
+            >
+              {pageNum}
+            </button>
+          );
+        })}
+
+        <button
+          onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+          disabled={currentPage === totalPages}
+          className="p-2 rounded-lg border border-border/80 hover:bg-muted text-muted-foreground disabled:opacity-40 disabled:hover:bg-transparent transition-all active:scale-95 h-8 w-8 flex items-center justify-center"
+          aria-label="Next page"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/features/index.ts
+++ b/components/features/index.ts
@@ -4,3 +4,5 @@ export { default as HeroSection } from "./HeroSection";
 export { default as StatsGrid } from "./StatsGrid";
 export { default as SectionWrapper } from "./SectionWrapper";
 export { default as ProjectsList } from "./ProjectsList";
+export { default as ProjectsFilterBar } from "./ProjectsFilterBar";
+export { default as ProjectsPagination } from "./ProjectsPagination";

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -12,6 +12,30 @@ export interface GithubRepo {
   language: string | null;
   fork: boolean;
   updated_at: string;
+  default_branch: string;
+}
+
+interface GraphQLCommitInfo {
+  message: string;
+  oid: string;
+}
+
+interface GraphQLBranchRef {
+  name: string;
+  target: GraphQLCommitInfo | null;
+}
+
+interface GraphQLRepoNode {
+  name: string;
+  defaultBranchRef: GraphQLBranchRef | null;
+}
+
+interface GraphQLReposData {
+  repositoryOwner: {
+    repositories: {
+      nodes: GraphQLRepoNode[];
+    };
+  };
 }
 
 export function getGithubUsername(): string {
@@ -64,6 +88,43 @@ export async function fetchGithubRepos(): Promise<GithubRepo[]> {
   return repos || [];
 }
 
+// GraphQL client for batch queries
+async function githubGraphQLFetch<T>(query: string, variables?: Record<string, unknown>): Promise<T | null> {
+  const token = process.env.GITHUB_TOKEN;
+  const headers = new Headers();
+  headers.set("Content-Type", "application/json");
+  headers.set("Accept", "application/vnd.github+json");
+  headers.set("User-Agent", "bharatbhusal-portfolio");
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  try {
+    const response = await fetch("https://api.github.com/graphql", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ query, variables }),
+      next: { revalidate: 3600 },
+    });
+
+    if (!response.ok) {
+      console.error(`GitHub GraphQL error: ${response.status} ${response.statusText}`);
+      return null;
+    }
+
+    const json = await response.json();
+    if (json.errors) {
+      console.error("GitHub GraphQL errors:", json.errors);
+      return null;
+    }
+
+    return json.data as T;
+  } catch (error) {
+    console.error("GitHub GraphQL fetch failed:", error);
+    return null;
+  }
+}
+
 export async function getGithubProjects(): Promise<ProjectItem[]> {
   const repos = await fetchGithubRepos();
 
@@ -71,34 +132,32 @@ export async function getGithubProjects(): Promise<ProjectItem[]> {
     return [];
   }
 
-  // Filter out forks so only original repositories are shown
-  const sourceRepos = repos.filter(repo => !repo.fork);
+  const shyTopics = ["pin", "shy"];
 
-  const mappedProjects: ProjectItem[] = sourceRepos.map(repo => {
+  // Filter out repos with "shy" topic
+  const visibleRepos = repos.filter(
+    repo => !repo.topics?.some(t => shyTopics.includes(t.toLowerCase()))
+  );
+
+  const mappedProjects: ProjectItem[] = visibleRepos.map(repo => {
     const links = [
       { link: repo.html_url, type: "github", icon: null as any }
     ] as any[];
 
-    // Add homepage link if it exists on GitHub
     if (repo.homepage) {
       links.push({ link: repo.homepage, type: "website", icon: null as any });
     }
 
-    // Add internal details link for README page
     links.push({ link: `/projects/${repo.name}`, type: "details", icon: null as any });
 
-    // Check if the repo has 'pin' (case-insensitive) in its topics
     const isPinned = repo.topics?.some(t => t.toLowerCase() === "pin");
 
     return {
       project: formatRepoName(repo.name),
       description: repo.description || "No description provided.",
-      // Show topics directly, filtering out the system 'pin' topic. Fallback to main language.
-      technologies: (repo.topics && repo.topics.length > 0)
-        ? repo.topics.filter(t => t.toLowerCase() !== "pin")
-        : repo.language
-          ? [repo.language]
-          : [],
+      technologies: repo.topics?.filter(
+        t => !shyTopics.includes(t.toLowerCase())
+      ) || [],
       links,
       highlight: isPinned ? "PINNED" : undefined,
       stars: repo.stargazers_count,
@@ -108,7 +167,52 @@ export async function getGithubProjects(): Promise<ProjectItem[]> {
     };
   });
 
-  return mappedProjects;
+  // Batch-fetch latest commits for all repos in a single GraphQL call
+  const commitQuery = `
+    query ReposWithDefaultBranch($username: String!) {
+      repositoryOwner(login: $username) {
+        repositories(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            name
+            defaultBranchRef {
+              name
+              target {
+                ... on Commit {
+                  message
+                  oid
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const commitData = await githubGraphQLFetch<GraphQLReposData>(commitQuery, { username: getGithubUsername() });
+  const commitMap = new Map<string, { branch: string; message: string }>();
+
+  if (commitData?.repositoryOwner?.repositories?.nodes) {
+    for (const node of commitData.repositoryOwner.repositories.nodes) {
+      if (node.defaultBranchRef?.target) {
+        commitMap.set(node.name, {
+          branch: node.defaultBranchRef.name,
+          message: node.defaultBranchRef.target.message,
+        });
+      }
+    }
+  }
+
+  return mappedProjects.map(project => {
+    const repo = visibleRepos.find(r => formatRepoName(r.name) === project.project);
+    if (!repo) return project;
+    const commit = commitMap.get(repo.name);
+    if (!commit) return project;
+    return {
+      ...project,
+      latestCommit: commit,
+    };
+  });
 }
 
 export async function getGithubRepoDetails(repoName: string): Promise<any | null> {

--- a/types/index.ts
+++ b/types/index.ts
@@ -45,6 +45,11 @@ export interface ProjectLink extends Link {
   type: "website" | "github" | "details";
 }
 
+export interface LatestCommit {
+  branch: string;
+  message: string;
+}
+
 export interface ProjectItem {
   project: string;
   description: string;
@@ -55,6 +60,7 @@ export interface ProjectItem {
   forks?: number;
   updatedAt?: string;
   language?: string;
+  latestCommit?: LatestCommit;
 }
 
 export interface SocialLink {


### PR DESCRIPTION
## Summary

Refactors the project section with route groups, dynamic GitHub data fetching, filtering, pagination, and a refreshed layout across career and education pages.

## Changes

- **Route groups:** projects list and dynamic `[repoName]` routes with dedicated layouts and loading states
- **Filtering and pagination:** filter bar and pagination components for dynamic project browsing
- **GitHub integration:** fetches repos, READMEs, and stats; Mermaid renderer for diagrams in READMEs
- **Project detail pages:** dynamic routes rendering full GitHub project metadata and README
- **Layout refactor:** replaced sidebar with header, footer, mobile nav; new hero section, stats grid, section wrapper for career and education pages
- **UI components:** alert-dialog, alert, dialog, dropdown-menu, sheet, skeleton
- **Removed:** old ProjectsCard, Explore sidebar, ThemeSwitcher, static projects data (replaced by GitHub API)


## Notes

- Static projects data file deleted — projects are now fetched dynamically from GitHub
- Icon migrated from public to app directory
- CI workflow removed
- Added customization and architecture docs
- Cleaned up unused directive in education data