### PR TITLE
docs: use /public/assets absolute image paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,25 @@ A modern, minimal, and fully dynamic portfolio website built with **Next.js 15**
 
 For architectural patterns, developer guidelines, and customization walkthroughs, refer to the documentation:
 
-*   [High-Level Design (HLD)](docs/HLD.md) — System boundaries, data caching flow, and Next.js route groups.
-*   [Low-Level Design (LLD) ](docs/LLD.md) — State hooks, code interfaces, pagination logic, and hydration fixes.
-*   [User Journey](docs/USER_JOURNEY.md) — Step-by-step visitor search sequence diagrams and interface states.
-*   [How to Fork & Customize](docs/CUSTOMIZE.md) — Guide on environment setups, profile assets, and static data arrays.
-*   [Screenshots Walkthrough](docs/screenshots.md) — Visual tour of every page with captured screenshots.
+- [High-Level Design (HLD)](docs/HLD.md) — System boundaries, data caching flow, and Next.js route groups.
+- [Low-Level Design (LLD) ](docs/LLD.md) — State hooks, code interfaces, pagination logic, and hydration fixes.
+- [User Journey](docs/USER_JOURNEY.md) — Step-by-step visitor search sequence diagrams and interface states.
+- [How to Fork & Customize](docs/CUSTOMIZE.md) — Guide on environment setups, profile assets, and static data arrays.
+- [Screenshots Walkthrough](docs/screenshots.md) — Visual tour of every page with captured screenshots.
 
 ---
 
 ## Features
 
 ### Core
+
 - **Dark/Light Theme**: Smooth theme switching via a toggle in the header (persisted with `next-themes`).
 - **vCard QR Code**: Interactive profile toggle (Avatar photo $\leftrightarrow$ save-contact QR code) using `qrcode.react`.
 - **GSAP Animations**: Micro-animations and entrance reveals for text headings and cards.
 - **Responsive Layout**: Mobile-first grid layouts matching sm/md/lg/xl browser breakpoints.
 
 ### Projects & GitHub Integration
+
 - **Live Repository Fetching**: Retrieves repositories, stars, forks, primary languages, and last updated dates on the server using a unified fetch client.
 - **Toglable Search & Sorting**: Instant client-side text query search with an absolute results count badge. Sorting buttons toggle sort directions (`asc`/`desc`) dynamically.
 - **Dropdown Topic Filtering**: Groups all unique topics across repositories in a clean dropdown menu including repository counts next to each tag.
@@ -36,6 +38,7 @@ For architectural patterns, developer guidelines, and customization walkthroughs
 ## Getting Started
 
 ### 1. Fork and Clone
+
 ```bash
 git clone https://github.com/yourusername/portfolio.git
 cd portfolio
@@ -43,7 +46,9 @@ npm install
 ```
 
 ### 2. Environment Configurations
+
 Create a `.env` (or `.env.local`) file in the root directory:
+
 ```env
 GITHUB_USERNAME=yourusername
 NEXT_PUBLIC_GITHUB_USERNAME=yourusername
@@ -51,11 +56,13 @@ GITHUB_TOKEN=ghp_yourtokenhere
 ```
 
 ### 3. Local Development
+
 ```bash
 npm run dev
 ```
 
 ### 4. Build for Production
+
 ```bash
 npm run build
 npm start
@@ -67,4 +74,4 @@ npm start
 
 ### Main Page
 
-![Main Page](public/assets/home.png)
+![Main Page](/public/assets/home.png)

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -3,13 +3,13 @@
 A visual walkthrough of every page in the portfolio site. The app is a
 Next.js 15 project; run it locally with `npm run dev` (default URL
 `http://localhost:3000`). Screenshots below are viewport captures of each
-route, saved under `public/assets/`.
+route, saved under `/public/assets/`.
 
 ## Pages
 
 ### Home (`/`)
 
-![Home](public/assets/home.png)
+![Home](/public/assets/home.png)
 
 - **How to get there:** The landing page, served at the root URL.
 - **What it shows:** The hero/intro section with the avatar, name, and a
@@ -18,7 +18,7 @@ route, saved under `public/assets/`.
 
 ### Projects (`/projects`)
 
-![Projects](public/assets/projects.png)
+![Projects](/public/assets/projects.png)
 
 - **How to get there:** Header navigation item "Projects" or direct URL
   `/projects`.
@@ -30,7 +30,7 @@ route, saved under `public/assets/`.
 
 ### Project Detail (`/projects/[repoName]`)
 
-![Project Detail](public/assets/project-detail.png)
+![Project Detail](/public/assets/project-detail.png)
 
 - **How to get there:** Click "Readme" on any project card, e.g.
   `/projects/openworld`.
@@ -41,7 +41,7 @@ route, saved under `public/assets/`.
 
 ### Career (`/career`)
 
-![Career](public/assets/career.png)
+![Career](/public/assets/career.png)
 
 - **How to get there:** Header navigation item "Career" or direct URL
   `/career`.
@@ -50,7 +50,7 @@ route, saved under `public/assets/`.
 
 ### Education (`/education`)
 
-![Education](public/assets/education.png)
+![Education](/public/assets/education.png)
 
 - **How to get there:** Header navigation item "Education" or direct URL
   `/education`.


### PR DESCRIPTION
## Summary
- Updates the page-screenshot image embeds to use absolute `/public/assets/...` paths instead of relative `public/assets/...` in both `docs/screenshots.md` and `README.md`.

## Why
- The original PR (#36) was squash-merged without this follow-up fix, so the image references still pointed at the relative path. This PR applies the path fix to `develop`.

## Changed files
- `docs/screenshots.md` — all page image links now use `/public/assets/<slug>.png`.
- `README.md` — landing-page embed now uses `/public/assets/home.png`.

🤖 Generated with [opencode](https://opencode.ai)