### PR TITLE
refactor: improve resume generation with structured prompts and richer project context

### DIFF
--- a/app/api/resume/generate/route.ts
+++ b/app/api/resume/generate/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { buildResumeContext, buildPrompt } from "@/lib/resume";
+import { buildResumeContext, buildSystemPrompt, buildUserPrompt, postProcessResume } from "@/lib/resume";
 import { generateResume } from "@/lib/llm";
 import { getResumesCollection } from "@/lib/mongodb";
 import { checkApiRateLimit, checkPdfRateLimit, extractIp } from "@/lib/rate-limit";
@@ -33,8 +33,10 @@ export async function POST(req: NextRequest) {
     }
 
     const ctx = await buildResumeContext();
-    const prompt = buildPrompt(ctx, role);
-    const resume = await generateResume(prompt);
+    const systemPrompt = buildSystemPrompt(role);
+    const userPrompt = buildUserPrompt(ctx, role);
+    const rawOutput = await generateResume(systemPrompt, userPrompt);
+    const resume = postProcessResume(rawOutput as unknown as Record<string, unknown>, ctx);
 
     // Save to MongoDB
     const col = await getResumesCollection();

--- a/app/api/resume/latest/route.ts
+++ b/app/api/resume/latest/route.ts
@@ -7,5 +7,11 @@ export async function GET() {
   if (!doc) {
     return NextResponse.json(null);
   }
-  return NextResponse.json(serializeId(doc), { headers: { "Cache-Control": "public, max-age=60" } });
+  const serialized = serializeId(doc);
+  if (process.env.NODE_ENV === "development") {
+    serialized.createdAt = new Date(0).toISOString();
+  }
+  return NextResponse.json(serialized, {
+    headers: { "Cache-Control": "public, max-age=60" },
+  });
 }

--- a/components/cards/CareerCard.tsx
+++ b/components/cards/CareerCard.tsx
@@ -23,7 +23,8 @@ const iconMap: Record<string, React.ComponentType<React.SVGProps<SVGSVGElement>>
 const CareerCard = ({
   company,
   role,
-  duration,
+  startDate,
+  endDate,
   address,
   description,
   achievements,
@@ -45,7 +46,7 @@ const CareerCard = ({
             <p className="text-primary font-medium text-sm">{role}</p>
           </div>
           <span className="text-xs text-muted-foreground whitespace-nowrap">
-            {duration}
+            {startDate} – {endDate || "Present"}
           </span>
         </div>
 

--- a/components/cards/EducationCard.tsx
+++ b/components/cards/EducationCard.tsx
@@ -24,7 +24,8 @@ const iconMap: Record<string, React.ComponentType<React.SVGProps<SVGSVGElement>>
 const EducationCard = ({
   institution,
   degree,
-  duration,
+  startDate,
+  endDate,
   address,
   cgpa,
   description,
@@ -49,7 +50,7 @@ const EducationCard = ({
             )}
           </div>
           <span className="text-xs text-muted-foreground whitespace-nowrap">
-            {duration}
+            {startDate} – {endDate || ""}
           </span>
         </div>
 

--- a/components/resume/ResumePDF.tsx
+++ b/components/resume/ResumePDF.tsx
@@ -90,7 +90,10 @@ function ResumeDoc({ data }: { data: ResumeData }) {
           <Text style={styles.name}>{basics.name}</Text>
           <View style={styles.contactCol}>
             {basics.email && (
-              <PdfLink href={`mailto:${basics.email}`} style={styles.contactLink}>
+              <PdfLink
+                href={`mailto:${basics.email}`}
+                style={styles.contactLink}
+              >
                 {basics.email}
               </PdfLink>
             )}
@@ -101,7 +104,7 @@ function ResumeDoc({ data }: { data: ResumeData }) {
             )}
             {basics.url && (
               <PdfLink href={basics.url} style={styles.contactLink}>
-                {basics.url}
+                {basics.url.replace(/^https?:\/\//, "")}
               </PdfLink>
             )}
           </View>
@@ -137,7 +140,10 @@ function ResumeDoc({ data }: { data: ResumeData }) {
                     {w.startDate} – {w.endDate || "Present"}
                   </Text>
                 </View>
-                <Text style={styles.italic}>{w.company}</Text>
+                <Text style={styles.italic}>
+                  {w.company}
+                  {w.location ? ` · ${w.location}` : ""}
+                </Text>
                 {w.highlights.map((h, j) => (
                   <View key={j} style={styles.bulletRow}>
                     <Text style={styles.bullet}>•</Text>
@@ -156,9 +162,12 @@ function ResumeDoc({ data }: { data: ResumeData }) {
             {projects.map((p, i) => (
               <View key={i} style={styles.row}>
                 <Text style={styles.bold}>{p.name}</Text>
-                <Text style={{ fontSize: 9.5, color: "#333", marginTop: 1 }}>
-                  {p.description}
-                </Text>
+                {p.highlights.map((h, j) => (
+                  <View key={j} style={styles.bulletRow}>
+                    <Text style={styles.bullet}>•</Text>
+                    <Text style={styles.bulletText}>{h}</Text>
+                  </View>
+                ))}
                 {p.techStack.length > 0 && (
                   <Text style={styles.projectTech}>
                     {p.techStack.join(" · ")}
@@ -166,7 +175,7 @@ function ResumeDoc({ data }: { data: ResumeData }) {
                 )}
                 {p.url && (
                   <PdfLink href={p.url} style={styles.projectLink}>
-                    {p.url}
+                    {p.url.replace(/^https?:\/\//, "")}
                   </PdfLink>
                 )}
               </View>

--- a/components/resume/ResumePreview.tsx
+++ b/components/resume/ResumePreview.tsx
@@ -40,7 +40,7 @@ export default function ResumePreview({ data }: { data: ResumeData }) {
                 className="hover:underline"
                 style={{ color: GREEN }}
               >
-                {basics.url}
+                {basics.url.replace(/^https?:\/\//, "")}
               </a>
             )}
           </div>
@@ -90,7 +90,10 @@ export default function ResumePreview({ data }: { data: ResumeData }) {
                     {w.startDate} – {w.endDate || "Present"}
                   </span>
                 </div>
-                <div className="text-gray-600 italic">{w.company}</div>
+                <div className="text-gray-600 italic">
+                  {w.company}
+                  {w.location ? ` · ${w.location}` : ""}
+                </div>
                 {w.highlights.length > 0 && (
                   <ul className="mt-1 ml-4 list-disc space-y-0.5">
                     {w.highlights.map((h, j) => (
@@ -117,7 +120,13 @@ export default function ResumePreview({ data }: { data: ResumeData }) {
             {projects.map((p, i) => (
               <div key={i}>
                 <div className="font-bold">{p.name}</div>
-                <div className="text-gray-700">{p.description}</div>
+                {p.highlights.length > 0 && (
+                  <ul className="mt-1 ml-4 list-disc space-y-0.5">
+                    {p.highlights.map((h, j) => (
+                      <li key={j}>{h}</li>
+                    ))}
+                  </ul>
+                )}
                 {p.techStack.length > 0 && (
                   <div className="text-gray-500 text-[10px] mt-0.5">
                     {p.techStack.join(" · ")}
@@ -131,7 +140,7 @@ export default function ResumePreview({ data }: { data: ResumeData }) {
                     className="text-[10px] hover:underline"
                     style={{ color: GREEN }}
                   >
-                    {p.url}
+                    {p.url.replace(/^https?:\/\//, "")}
                   </a>
                 )}
               </div>

--- a/data/careerData.ts
+++ b/data/careerData.ts
@@ -7,7 +7,8 @@ const careerData: CareerItem[] = [
   {
     company: "Keyloop",
     role: "Software Engineer",
-    duration: "Nov 2025 - Present",
+    startDate: "Nov 2025",
+    endDate: "Present",
     address: "Hybrid",
     description: `An integrated platform for automotive retailers, OEMs, fleet providers and financiers. A smarter, simpler journey for car buyers and owners.`,
     achievements: [
@@ -38,7 +39,8 @@ const careerData: CareerItem[] = [
   {
     company: "Kanine Klans",
     role: "Blockchain Engineer",
-    duration: "Apr 2025 - Aug 2025",
+    startDate: "Apr 2025",
+    endDate: "Aug 2025",
     address: "Remote",
     description: `MASTER THE ELEMENTS, DOMINATE MARS! Strategize Your Moves. Explore Uncharted Land, And Rise To Supremacy On The Red Planet.`,
     achievements: [
@@ -67,7 +69,8 @@ const careerData: CareerItem[] = [
   {
     company: "jaisriram",
     role: "Fullstack Blockchain Developer",
-    duration: "Oct 2024 - Apr 2025",
+    startDate: "Oct 2024",
+    endDate: "Apr 2025",
     address: "Remote",
     description: `Embark on a transformative journey with $JSR, evolving from a devoted seeker to the enlightened master of "Chant-to-Earn."`,
     achievements: [
@@ -105,7 +108,8 @@ const careerData: CareerItem[] = [
   {
     company: "Router Protocol",
     role: "Community Manager",
-    duration: "Oct 2023 - Feb 2025",
+    startDate: "Oct 2023",
+    endDate: "Feb 2025",
     address: "Remote",
     description:
       "Bridging blockchain ecosystems to onboard the next billion users into Web3 by eliminating blockchain fragmentation.",
@@ -135,12 +139,13 @@ const careerData: CareerItem[] = [
   {
     company: "0xCommit",
     role: "Security Auditor and Community Manager",
-    duration: "Feb 2024 - Oct 2024",
+    startDate: "Feb 2024",
+    endDate: "Oct 2024",
     address: "Remote",
     description:
       "Enhancing the security of decentralized systems through comprehensive smart contract audits.",
     achievements: [
-      "Conducted independent and collaborative audits of over 20 client’s smart contracts.",
+      "Conducted independent and collaborative audits of over 20 client's smart contracts.",
       "Prepared more than 20 detailed audit reports with clear, concise explanations of identified vulnerabilities.",
       "Established a new community centered on smart contract security and audits. In 1 week successfully gathered 20+ genuine security enthusiasts.",
       "Consistently created and shared around 21 educational content per week, including articles and social media updates.",
@@ -168,7 +173,8 @@ const careerData: CareerItem[] = [
   {
     company: "Terraform Labs",
     role: "Community Moderator",
-    duration: "Sept 2021 - Aug 2023",
+    startDate: "Sept 2021",
+    endDate: "Aug 2023",
     address: "Remote",
     description:
       "Supporting a passionate community and developer ecosystem to drive innovation within the Terra blockchain network.",

--- a/data/educationData.ts
+++ b/data/educationData.ts
@@ -6,7 +6,8 @@ import { EducationItem } from "@/types";
 const educationData: EducationItem[] = [
   {
     institution: "GITAM University",
-    duration: "Nov 2021 - Apr 2025",
+    startDate: "Nov 2021",
+    endDate: "Apr 2025",
     address: "Hyderabad, India",
     cgpa: "9.11/10 (Gold Medalist)",
     degree: "B.Tech in Computer Science & Engineering",
@@ -45,7 +46,8 @@ const educationData: EducationItem[] = [
   },
   {
     institution: "Kathmandu World School",
-    duration: "2019 - 2020",
+    startDate: "2019",
+    endDate: "2020",
     address: "Bhaktapur, Nepal",
     cgpa: "3.61/4",
     degree: "Higher Secondary Education (Science)",
@@ -78,7 +80,8 @@ const educationData: EducationItem[] = [
   },
   {
     institution: "SOS Hermann Gmeiner Higher Secondary School",
-    duration: "2017 - 2018",
+    startDate: "2017",
+    endDate: "2018",
     address: "Surkhet, Nepal",
     degree: "Secondary Education (Science)",
     cgpa: "9.14/10",

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -282,8 +282,7 @@ export async function getGithubPinnedReposWithReadme(): Promise<
     .sort(
       (a, b) =>
         new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
-    )
-    .slice(0, 5);
+    );
 
   const results: PinnedRepoWithReadme[] = [];
   for (const repo of pinnedRepos) {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -40,7 +40,9 @@ interface GraphQLReposData {
 }
 
 export function getGithubUsername(): string {
-  return process.env.GITHUB_USERNAME || contactInfo.social.github.split("/").pop()!;
+  return (
+    process.env.GITHUB_USERNAME || contactInfo.social.github.split("/").pop()!
+  );
 }
 
 // Dedicated central client for all GitHub API requests
@@ -67,7 +69,10 @@ async function githubFetch<T>(
     const response = await fetch(url, {
       ...options,
       headers,
-      next: { revalidate: 3600, ...options?.next }, // Cache for 1 hour by default
+      next: {
+        revalidate: process.env.NODE_ENV === "development" ? 0 : 3600,
+        ...options?.next,
+      },
     });
 
     if (!response.ok) {
@@ -111,7 +116,7 @@ async function githubGraphQLFetch<T>(
       method: "POST",
       headers,
       body: JSON.stringify({ query, variables }),
-      next: { revalidate: 3600 },
+      next: { revalidate: process.env.NODE_ENV === "development" ? 0 : 3600 },
     });
 
     if (!response.ok) {
@@ -251,6 +256,58 @@ export async function getGithubRepoReadme(repoName: string): Promise<string> {
     return Buffer.from(cleanBase64, "base64").toString("utf8");
   }
   return "";
+}
+
+export interface PinnedRepoWithReadme {
+  name: string;
+  description: string;
+  tags: string[];
+  links: { type: string; url: string }[];
+  readmeContent: string;
+  language: string | null;
+}
+
+export async function getGithubPinnedReposWithReadme(): Promise<
+  PinnedRepoWithReadme[]
+> {
+  const repos = await fetchGithubRepos();
+  const shyTopics = ["shy"];
+
+  const pinnedRepos = repos
+    .filter(
+      (repo) =>
+        repo.topics?.some((t) => t.toLowerCase() === "pin") &&
+        !repo.topics?.some((t) => shyTopics.includes(t.toLowerCase())),
+    )
+    .sort(
+      (a, b) =>
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+    )
+    .slice(0, 5);
+
+  const results: PinnedRepoWithReadme[] = [];
+  for (const repo of pinnedRepos) {
+    const readmeRaw = await getGithubRepoReadme(repo.name);
+    const links: { type: string; url: string }[] = [
+      { type: "github", url: repo.html_url },
+    ];
+    if (repo.homepage) {
+      links.push({ type: "website", url: repo.homepage });
+    }
+    results.push({
+      name: formatRepoName(repo.name),
+      description: repo.description || "No description provided.",
+      tags:
+        repo.topics?.filter(
+          (t) => !shyTopics.includes(t.toLowerCase()) && t !== "pin",
+        ) || [],
+      links,
+      readmeContent: readmeRaw,
+      language: repo.language || null,
+    });
+  }
+
+  return results;
 }
 
 function formatRepoName(name: string): string {

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -3,10 +3,15 @@ import type { ResumeData } from "@/types/resume";
 const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
 const MODEL = "llama-3.3-70b-versatile";
 
-export async function generateResume(prompt: string): Promise<ResumeData> {
+export async function generateResume(
+  systemPrompt: string,
+  userPrompt: string,
+): Promise<ResumeData> {
   const apiKey = process.env.GROQ_API_KEY;
   if (!apiKey) {
-    throw new Error("GROQ_API_KEY not set. Get one free at https://console.groq.com/keys");
+    throw new Error(
+      "GROQ_API_KEY not set. Get one free at https://console.groq.com/keys",
+    );
   }
 
   const res = await fetch(GROQ_URL, {
@@ -15,14 +20,12 @@ export async function generateResume(prompt: string): Promise<ResumeData> {
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
     },
+    cache: process.env.NODE_ENV === "development" ? "no-store" : undefined,
     body: JSON.stringify({
       model: MODEL,
       messages: [
-        {
-          role: "system",
-          content: "Output ONLY valid JSON. No markdown, no explanation, just the JSON object.",
-        },
-        { role: "user", content: prompt },
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
       ],
       temperature: 0.7,
       max_tokens: 4096,
@@ -40,10 +43,10 @@ export async function generateResume(prompt: string): Promise<ResumeData> {
   const text = data.choices?.[0]?.message?.content;
   if (!text) throw new Error("Empty response from Groq");
 
-  const parsed = JSON.parse(text) as ResumeData;
-  if (!parsed.basics?.name || !Array.isArray(parsed.work)) {
+  const parsed = JSON.parse(text) as Record<string, unknown>;
+  if (!Array.isArray(parsed.work)) {
     throw new Error("Invalid resume structure from LLM");
   }
 
-  return parsed;
+  return parsed as unknown as ResumeData;
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -5,6 +5,8 @@ export async function checkApiRateLimit(
   ip: string,
   windowMs = 10 * 60_000,
 ): Promise<{ allowed: boolean; retryAfterMs?: number }> {
+  if (process.env.NODE_ENV === "development") return { allowed: true };
+
   const col = await getRateLimitsCollection();
   const now = new Date();
   const cutoff = new Date(now.getTime() - windowMs);
@@ -28,6 +30,8 @@ export function checkPdfRateLimit(): {
   allowed: boolean;
   retryAfterMs?: number;
 } {
+  if (process.env.NODE_ENV === "development") return { allowed: true };
+
   const now = Date.now();
   if (now - lastPdfGeneration < PDF_WINDOW_MS) {
     return {

--- a/lib/resume.ts
+++ b/lib/resume.ts
@@ -1,18 +1,138 @@
 import { contactInfo } from "@/config/contact-info";
 import careerData from "@/data/careerData";
 import educationData from "@/data/educationData";
-import { getGithubProjects } from "@/lib/github";
+import { getGithubPinnedReposWithReadme } from "@/lib/github";
 import type { ResumeData, JobRole } from "@/types/resume";
 
+function parseStartDate(dateStr: string): number {
+  const months: Record<string, number> = {
+    Jan: 0,
+    Feb: 1,
+    Mar: 2,
+    Apr: 3,
+    May: 4,
+    Jun: 5,
+    Jul: 6,
+    Aug: 7,
+    Sept: 8,
+    Sep: 8,
+    Oct: 9,
+    Nov: 10,
+    Dec: 11,
+  };
+  const parts = dateStr.split(" ");
+  if (parts.length < 2) return 0;
+  const month = months[parts[0]] ?? 0;
+  const year = parseInt(parts[1], 10) || 0;
+  return year * 100 + month;
+}
+
 export async function buildResumeContext(): Promise<{
-  basics: ResumeData["basics"];
-  work: ResumeData["work"];
-  education: ResumeData["education"];
-  projects: { name: string; description: string; tags: string[] }[];
-  skills: string[];
+  work: {
+    company: string;
+    address: string;
+    highlights: string[];
+  }[];
+  projects: {
+    name: string;
+    description: string;
+    tags: string[];
+    readmeContent: string;
+    links: { type: string; url: string }[];
+  }[];
 }> {
-  const projects = await getGithubProjects();
-  const featuredProjects = projects.slice(0, 20);
+  const pinnedRepos = await getGithubPinnedReposWithReadme();
+
+  return {
+    work: careerData.map((c) => ({
+      company: c.company,
+      address: c.address,
+      highlights: c.achievements,
+    })),
+    projects: pinnedRepos.map((p) => ({
+      name: p.name,
+      description: p.description,
+      tags: p.tags,
+      readmeContent: p.readmeContent,
+      links: p.links,
+    })),
+  };
+}
+
+export function buildSystemPrompt(role: JobRole): string {
+  return `You are an expert ATS-friendly resume writer. You create tailored, ATS-optimized resumes.
+
+RULES:
+- Output ONLY valid JSON matching the schema below. No markdown, no explanation.
+- Reorder and emphasize work experience to highlight relevance to "${role}".
+- Write a 2-3 line professional summary tailored to "${role}" based on work experience and projects.
+- Quantify achievements with numbers where possible.
+- Use ATS-friendly keywords relevant to "${role}".
+- For projects: explain each project in 2-4 bullet points based on the README content provided.
+- List skills in categories relevant to "${role}" (e.g., Languages, Frameworks, Tools, Platforms) based on work experience and projects.
+- Use reverse chronological order for work and education.
+- Keep bullet points concise (1-2 lines each).
+
+OUTPUT SCHEMA:
+{
+  "summary": "2-3 line professional summary tailored to the role",
+  "skills": [
+    {
+      "category": "string (e.g., Languages, Frameworks, Tools)",
+      "keywords": ["string"]
+    }
+  ],
+  "work": [
+    {
+      "company": "string",
+      "highlights": ["string (concise, quantified, ATS-optimized bullets)"]
+    }
+  ],
+  "projects": [
+    {
+      "name": "string",
+      "highlights": ["string (2-4 bullet points explaining the project based on README)"],
+      "techStack": ["string"]
+    }
+  ]
+}`;
+}
+
+export function buildUserPrompt(
+  ctx: Awaited<ReturnType<typeof buildResumeContext>>,
+  role: JobRole,
+): string {
+  return `Create a resume for the role of "${role}".
+
+RAW DATA:
+${JSON.stringify(ctx, null, 2)}`;
+}
+
+export function postProcessResume(
+  llmOutput: Record<string, unknown>,
+  ctx: Awaited<ReturnType<typeof buildResumeContext>>,
+): ResumeData {
+  const workMap = new Map(careerData.map((c) => [c.company, c]));
+
+  const llmWork = (llmOutput.work || []) as {
+    company: string;
+    highlights: string[];
+  }[];
+
+  const llmProjects = (llmOutput.projects || []) as {
+    name: string;
+    highlights: string[];
+    techStack: string[];
+  }[];
+
+  const sortedWork = [...llmWork].sort((a, b) => {
+    const rawA = workMap.get(a.company);
+    const rawB = workMap.get(b.company);
+    return (
+      parseStartDate(rawB?.startDate || "") -
+      parseStartDate(rawA?.startDate || "")
+    );
+  });
 
   return {
     basics: {
@@ -20,95 +140,37 @@ export async function buildResumeContext(): Promise<{
       email: contactInfo.email,
       phone: contactInfo.phone,
       url: contactInfo.website,
-      summary: contactInfo.bio,
+      summary: (llmOutput.summary as string) || contactInfo.bio,
     },
-    work: careerData.map((c) => ({
-      company: c.company,
-      position: c.role,
-      startDate: c.duration.split(" - ")[0]?.trim() || "",
-      endDate: c.duration.split(" - ")[1]?.trim() || undefined,
-      highlights: c.achievements,
-    })),
+    work: sortedWork.map((w) => {
+      const raw = workMap.get(w.company);
+      return {
+        company: w.company,
+        position: raw?.role || "",
+        startDate: raw?.startDate || "",
+        endDate: raw?.endDate,
+        location: raw?.address || undefined,
+        highlights: w.highlights,
+      };
+    }),
     education: educationData.map((e) => ({
       institution: e.institution,
       degree: e.degree || "",
       area: e.courses?.join(", ") || "",
-      startDate: e.duration.split(" - ")[0]?.trim() || "",
-      endDate: e.duration.split(" - ")[1]?.trim() || undefined,
+      startDate: e.startDate,
+      endDate: e.endDate,
       gpa: e.cgpa,
     })),
-    projects: featuredProjects.map((p) => ({
-      name: p.project,
-      description: p.description,
-      tags: p.tags,
-    })),
-    skills: [
-      ...new Set(
-        featuredProjects.flatMap((p) => p.tags).filter(Boolean) as string[]
-      ),
-    ],
+    skills: (llmOutput.skills || []) as ResumeData["skills"],
+    projects: ctx.projects.map((ctxProject) => {
+      const llmProj = llmProjects.find((p) => p.name === ctxProject.name);
+      const homepage = ctxProject.links.find((l) => l.type === "website")?.url;
+      return {
+        name: ctxProject.name,
+        highlights: llmProj?.highlights || [ctxProject.description],
+        techStack: llmProj?.techStack || ctxProject.tags,
+        url: homepage || undefined,
+      };
+    }),
   };
-}
-
-export function buildPrompt(ctx: Awaited<ReturnType<typeof buildResumeContext>>, role: JobRole): string {
-  return `You are an expert ATS-friendly resume writer. Given the following raw data about a person, create a tailored, ATS-optimized resume for the role of "${role}".
-
-RULES:
-- Output ONLY valid JSON matching the schema below.
-- Reorder and emphasize work experience to highlight relevance to "${role}".
-- Write a 2-3 line professional summary tailored to "${role}".
-- Quantify achievements with numbers where possible.
-- Use ATS-friendly keywords relevant to "${role}".
-- Keep bullet points concise (1-2 lines each).
-- List skills in categories relevant to "${role}".
-- Include the most relevant 5-8 projects that match "${role}".
-- Use reverse chronological order for work and education.
-- Date format: "Mon YYYY" (e.g., "Nov 2025").
-
-OUTPUT SCHEMA:
-{
-  "basics": {
-    "name": "string",
-    "email": "string",
-    "phone": "string or null",
-    "url": "string or null",
-    "summary": "2-3 line professional summary tailored to the role"
-  },
-  "work": [
-    {
-      "company": "string",
-      "position": "string (tailored title if appropriate)",
-      "startDate": "Mon YYYY",
-      "endDate": "Mon YYYY or Present",
-      "highlights": ["string (concise, quantified, ATS-optimized bullets)"]
-    }
-  ],
-  "education": [
-    {
-      "institution": "string",
-      "degree": "string",
-      "area": "string (relevant coursework)",
-      "startDate": "Mon YYYY",
-      "endDate": "Mon YYYY",
-      "gpa": "string or null"
-    }
-  ],
-  "skills": [
-    {
-      "category": "string (e.g., Languages, Frameworks, Tools)",
-      "keywords": ["string"]
-    }
-  ],
-  "projects": [
-    {
-      "name": "string",
-      "description": "string (1-2 lines, relevant to role)",
-      "techStack": ["string"],
-      "url": "string or null"
-    }
-  ]
-}
-
-RAW DATA:
-${JSON.stringify(ctx, null, 2)}`;
 }

--- a/lib/resume.ts
+++ b/lib/resume.ts
@@ -69,7 +69,7 @@ RULES:
 - Quantify achievements with numbers where possible.
 - Use ATS-friendly keywords relevant to "${role}".
 - For projects: explain each project in 2-4 bullet points based on the README content provided.
-- List skills in categories relevant to "${role}" (e.g., Languages, Frameworks, Tools, Platforms) based on work experience and projects.
+- List all the skills in categories (e.g., Languages, Frameworks, Tools, Platforms) based on work experience and projects.
 - Use reverse chronological order for work and education.
 - Keep bullet points concise (1-2 lines each).
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -15,7 +15,8 @@ export interface CareerLink extends Link {
 export interface CareerItem {
   company: string;
   role: string;
-  duration: string;
+  startDate: string;
+  endDate?: string;
   address: string;
   description: string;
   achievements: string[];
@@ -30,7 +31,8 @@ export interface EducationLink extends Link {
 
 export interface EducationItem {
   institution: string;
-  duration: string;
+  startDate: string;
+  endDate?: string;
   address: string;
   cgpa: string;
   links: EducationLink[];

--- a/types/resume.ts
+++ b/types/resume.ts
@@ -13,6 +13,7 @@ export interface ResumeWork {
   position: string;
   startDate: string;
   endDate?: string;
+  location?: string;
   summary?: string;
   highlights: string[];
 }
@@ -33,7 +34,7 @@ export interface ResumeSkill {
 
 export interface ResumeProject {
   name: string;
-  description: string;
+  highlights: string[];
   techStack: string[];
   url?: string;
 }


### PR DESCRIPTION
## Summary

Refactors the LLM-powered resume generation pipeline and cleans up data structures across the portfolio.

## Changes

### Resume generation (`lib/resume.ts`, `lib/llm.ts`)
- Split monolithic `buildPrompt` into `buildSystemPrompt` + `buildUserPrompt` for clearer LLM instructions
- New `postProcessResume` merges LLM output with source data (work dates, education, project URLs) — LLM no longer needs to echo static fields
- Projects now include README content in context, so LLM generates better bullet points instead of echoing a one-liner description
- Simplified context payload: LLM receives only work highlights + project data, not basics/education/skills it would just echo back

### Data structures (`types/index.ts`, `data/careerData.ts`, `data/educationData.ts`)
- `duration: string` → `startDate` + `endDate` across `CareerItem` and `EducationItem`
- Components (`CareerCard`, `EducationCard`) updated to render the split fields

### Resume output (`components/resume/ResumePDF.tsx`, `components/resume/ResumePreview.tsx`)
- Projects render bullet-point highlights instead of a single description block
- URLs strip `https://` prefix for cleaner display
- Work entries show location alongside company name

### GitHub integration (`lib/github.ts`)
- New `getGithubPinnedReposWithReadme()` fetches pinned repos with their README content for richer LLM context
- Dev mode: API caching disabled (`revalidate: 0`), rate limits bypassed

### Dev experience (`lib/rate-limit.ts`, `app/api/resume/latest/route.ts`)
- Rate limits and PDF generation limits bypassed in development
- Latest resume endpoint returns a fixed `createdAt` in dev for stable snapshots

## Files changed (14)

| File | What |
|------|------|
| `lib/resume.ts` | Prompt split, context builder, post-processor |
| `lib/llm.ts` | Accept system+user prompts, dev cache control |
| `lib/github.ts` | `getGithubPinnedReposWithReadme`, dev cache |
| `lib/rate-limit.ts` | Dev bypass |
| `types/index.ts` | `startDate`/`endDate` fields |
| `types/resume.ts` | `location` on work, `highlights` on projects |
| `data/careerData.ts` | Split duration fields |
| `data/educationData.ts` | Split duration fields |
| `components/cards/CareerCard.tsx` | Render split dates |
| `components/cards/EducationCard.tsx` | Render split dates |
| `components/resume/ResumePDF.tsx` | Bullets, location, URL cleanup |
| `components/resume/ResumePreview.tsx` | Bullets, location, URL cleanup |
| `app/api/resume/generate/route.ts` | Use new prompt functions |
| `app/api/resume/latest/route.ts` | Dev createdAt override |
