### PR TITLE
fix: add raw.githubusercontent.com to image remote patterns

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "github-readme-streak-stats.herokuapp.com",
       },
+      {
+        protocol: "https",
+        hostname: "raw.githubusercontent.com",
+      },
     ],
   },
 };


### PR DESCRIPTION
## Problem

The project detail page (`/projects/[repoName]`) crashed on the Vercel preview deployment with a client-side React error. The root cause: `raw.githubusercontent.com` was not listed in `images.remotePatterns` in `next.config.ts`, so `next/image` rejected the external image URLs used in repository READMEs.

## Fix

Added `raw.githubusercontent.com` to `images.remotePatterns` in `next.config.ts`.

## Verification

- Clean build, zero warnings